### PR TITLE
feat(docs): expose mdBook pages as markdown artifacts

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -44,8 +44,13 @@ jobs:
         uses: peaceiris/actions-mdbook@v2
         with:
           mdbook-version: '0.4.49'
+      - name: Test markdown artifact builder
+        run: node scripts/build-markdown-artifacts.test.mjs
       - run: |
           cd kcl-book
           mdbook build
-
+      - name: Build markdown artifacts
+        run: node scripts/build-markdown-artifacts.mjs
+      - name: Check markdown artifacts
+        run: test -f kcl-book/book/__docs-markdown/docs/kcl-book/installation.html/index.md
 

--- a/scripts/build-markdown-artifacts.mjs
+++ b/scripts/build-markdown-artifacts.mjs
@@ -1,0 +1,85 @@
+import { mkdir, readFile, rm, writeFile } from 'node:fs/promises'
+import path from 'node:path'
+import { fileURLToPath, pathToFileURL } from 'node:url'
+
+export const DOCS_MARKDOWN_PUBLIC_ROUTE = '/__docs-markdown'
+export const DOCS_MARKDOWN_ACCEPT_HEADER_VALUE =
+  '(^|.*,\\s*)text/markdown(\\s*;[^,]*)?(\\s*,.*|$)'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const repoRoot = path.resolve(__dirname, '..')
+const defaultBookSourceDir = path.join(repoRoot, 'kcl-book', 'src')
+const defaultOutputRoot = path.join(
+  repoRoot,
+  'kcl-book',
+  'book',
+  DOCS_MARKDOWN_PUBLIC_ROUTE,
+  'docs',
+  'kcl-book'
+)
+
+export function parseSummaryFiles(summaryMarkdown) {
+  const files = []
+  const seen = new Set()
+  const pageLinkRegexp = /\]\(\.\/([^)#?]+\.md)(?:[#?][^)]*)?\)/g
+
+  for (const match of summaryMarkdown.matchAll(pageLinkRegexp)) {
+    const file = match[1]
+    if (file === 'SUMMARY.md' || seen.has(file)) continue
+    seen.add(file)
+    files.push(file)
+  }
+
+  return files
+}
+
+export function routePathForSourceFile(relativeSourcePath) {
+  const normalized = relativeSourcePath.replace(/\\/g, '/')
+  if (!/\.md$/i.test(normalized)) return null
+  if (normalized.toLowerCase() === 'summary.md') return null
+
+  return normalized.replace(/\.md$/i, '.html')
+}
+
+export function normalizeBookMarkdown(source) {
+  const markdown = source
+    .replace(/^\s*<!--\s*toc\s*-->\s*$/gim, '')
+    .replace(/\]\(\.\/([^)#?]+)\.md(#[^)]*)?\)/g, ']($1.html$2)')
+    .trim()
+
+  return `${markdown}\n`
+}
+
+async function writeMarkdown(outputRoot, routePath, markdown) {
+  const outputPath = path.join(outputRoot, routePath, 'index.md')
+  await mkdir(path.dirname(outputPath), { recursive: true })
+  await writeFile(outputPath, markdown, 'utf8')
+}
+
+export async function buildMarkdownArtifacts({
+  bookSourceDir = defaultBookSourceDir,
+  outputRoot = defaultOutputRoot,
+} = {}) {
+  await rm(outputRoot, { force: true, recursive: true })
+  await mkdir(outputRoot, { recursive: true })
+
+  const summary = await readFile(path.join(bookSourceDir, 'SUMMARY.md'), 'utf8')
+  const sourceFiles = parseSummaryFiles(summary)
+
+  for (const sourceFile of sourceFiles) {
+    const routePath = routePathForSourceFile(sourceFile)
+    if (!routePath) continue
+
+    const source = await readFile(path.join(bookSourceDir, sourceFile), 'utf8')
+    const markdown = normalizeBookMarkdown(source)
+    await writeMarkdown(outputRoot, routePath, markdown)
+
+    if (routePath === 'intro.html') {
+      await writeFile(path.join(outputRoot, 'index.md'), markdown, 'utf8')
+    }
+  }
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  await buildMarkdownArtifacts()
+}

--- a/scripts/build-markdown-artifacts.test.mjs
+++ b/scripts/build-markdown-artifacts.test.mjs
@@ -1,0 +1,110 @@
+import assert from 'node:assert/strict'
+import { mkdir, mkdtemp, readFile, writeFile } from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import test from 'node:test'
+
+import {
+  buildMarkdownArtifacts,
+  normalizeBookMarkdown,
+  parseSummaryFiles,
+  routePathForSourceFile,
+} from './build-markdown-artifacts.mjs'
+
+test('parses mdBook summary page links in order', () => {
+  assert.deepEqual(
+    parseSummaryFiles(`
+# Contents
+
+[Introduction](./intro.md)
+
+- [Install](./installation.md)
+- [Install again](./installation.md)
+- [Not a local page](https://example.com/nope.md)
+`),
+    ['intro.md', 'installation.md']
+  )
+})
+
+test('maps source pages to public html route paths', () => {
+  assert.equal(routePathForSourceFile('installation.md'), 'installation.html')
+  assert.equal(routePathForSourceFile('advanced/page.md'), 'advanced/page.html')
+  assert.equal(routePathForSourceFile('SUMMARY.md'), null)
+  assert.equal(routePathForSourceFile('images/static/part.png'), null)
+})
+
+test('normalizes mdBook-only markdown for curl output', () => {
+  assert.equal(
+    normalizeBookMarkdown(`
+<!-- toc -->
+
+# Page
+
+Read [next](./next.md#section).
+`),
+    '# Page\n\nRead [next](next.html#section).\n'
+  )
+})
+
+test('builds markdown artifacts for book pages and the intro alias', async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), 'kcl-book-markdown-'))
+  const bookSourceDir = path.join(root, 'src')
+  const outputRoot = path.join(root, 'out')
+
+  await mkdir(bookSourceDir, { recursive: true })
+  await writeFile(
+    path.join(bookSourceDir, 'SUMMARY.md'),
+    '[Introduction](./intro.md)\n\n- [Install](./installation.md)\n',
+    'utf8'
+  )
+  await writeFile(path.join(bookSourceDir, 'intro.md'), '# Intro\n', 'utf8')
+  await writeFile(
+    path.join(bookSourceDir, 'installation.md'),
+    '<!-- toc -->\n\n# Installation\n',
+    'utf8'
+  )
+
+  await buildMarkdownArtifacts({ bookSourceDir, outputRoot })
+
+  assert.equal(
+    await readFile(path.join(outputRoot, 'index.md'), 'utf8'),
+    '# Intro\n'
+  )
+  assert.equal(
+    await readFile(path.join(outputRoot, 'intro.html', 'index.md'), 'utf8'),
+    '# Intro\n'
+  )
+  assert.equal(
+    await readFile(
+      path.join(outputRoot, 'installation.html', 'index.md'),
+      'utf8'
+    ),
+    '# Installation\n'
+  )
+})
+
+test('declares markdown headers for deployed artifacts', async () => {
+  const vercelConfig = JSON.parse(
+    await readFile(new URL('../vercel.json', import.meta.url), 'utf8')
+  )
+
+  assert.deepEqual(vercelConfig.headers, [
+    {
+      source: '/__docs-markdown/:path*',
+      headers: [
+        {
+          key: 'Content-Type',
+          value: 'text/markdown; charset=utf-8',
+        },
+        {
+          key: 'X-Content-Type-Options',
+          value: 'nosniff',
+        },
+        {
+          key: 'X-Robots-Tag',
+          value: 'noindex',
+        },
+      ],
+    },
+  ])
+})

--- a/vercel-build.sh
+++ b/vercel-build.sh
@@ -3,10 +3,22 @@ set -euo pipefail
 
 # This is a build script intended to be consumed by Vercel, though it should work locally if your platform matches.
 
-# First install Rust because we need to compile mdbook-kcl
-curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-. "$HOME/.cargo/env"
-rustup install stable
+# First make sure Rust is available because we need to compile mdbook-kcl.
+if [ -f /rust/env ]; then
+  . /rust/env
+fi
+if [ -f "$HOME/.cargo/env" ]; then
+  . "$HOME/.cargo/env"
+fi
+
+if ! command -v cargo >/dev/null 2>&1; then
+  curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+  . "$HOME/.cargo/env"
+fi
+
+if command -v rustup >/dev/null 2>&1; then
+  rustup install stable
+fi
 
 # Make a temporary directory for binaries
 mkdir -p bin

--- a/vercel-build.sh
+++ b/vercel-build.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euo pipefail
 
 # This is a build script intended to be consumed by Vercel, though it should work locally if your platform matches.
 
@@ -24,3 +25,4 @@ tar -xvzf mdbook-toc.tar.gz -C bin
 export PATH="$(pwd)/bin:$PATH"
 which mdbook-kcl
 mdbook build kcl-book
+node scripts/build-markdown-artifacts.mjs

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,21 @@
+{
+  "headers": [
+    {
+      "source": "/__docs-markdown/:path*",
+      "headers": [
+        {
+          "key": "Content-Type",
+          "value": "text/markdown; charset=utf-8"
+        },
+        {
+          "key": "X-Content-Type-Options",
+          "value": "nosniff"
+        },
+        {
+          "key": "X-Robots-Tag",
+          "value": "noindex"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
- Generate normalized markdown under /__docs-markdown with safe headers.
- Run and verify the artifact builder in CI and Vercel builds.